### PR TITLE
Doc improvements

### DIFF
--- a/source/includes/_api.md
+++ b/source/includes/_api.md
@@ -668,3 +668,17 @@ includes | `rewards,creator,goals,pledge` | You can pass this `rewards`, `creato
 <aside class="success">
 Remember — you must pass the correct <code>access_token</code> from the user.
 </aside>
+
+
+## Advanced Usage
+### Requesting specific data
+
+```
+POST https://www.patreon.com/api/oauth2/api/campaigns/<campaign_id>/pledges?fields[pledge]=total_historical_amount_cents,is_paused&include=reward
+```
+
+To retrieve specific attributes or relationships other than the defaults, you can pass `fields` and `include` parameters respectively, each being comma-separated lists of attributes or resources.
+
+<aside class="note">
+For more information on requesting specific data, the <a href="http://jsonapi.org/format/#fetching">JSONAPI documentation</a> may be useful.
+</aside>

--- a/source/includes/_api.md
+++ b/source/includes/_api.md
@@ -324,7 +324,7 @@ This endpoint returns a JSON representation of the user's campaign, including it
 
 ### HTTP Request
 
-`GET https://api.patreon.com/oauth2/api/current_user/campaigns`
+`GET https://www.patreon.com/api/oauth2/api/current_user/campaigns`
 
 ### Query Parameters
 
@@ -442,7 +442,7 @@ The API response will also contain a links section which may be used to fetch th
 
 ### HTTP Request
 
-`GET https://api.patreon.com/oauth2/api/campaigns/<campaign_id>/pledges`
+`GET https://www.patreon.com/api/oauth2/api/campaigns/<campaign_id>/pledges`
 
 
 ### Paging
@@ -657,7 +657,7 @@ This API returns a JSON representation of the user who granted your OAuth client
 
 ### HTTP Request
 
-`GET https://api.patreon.com/oauth2/api/current_user`
+`GET https://www.patreon.com/api/oauth2/api/current_user`
 
 ### Query Parameters
 

--- a/source/includes/_faqs.md
+++ b/source/includes/_faqs.md
@@ -1,0 +1,13 @@
+# FAQs
+## Testing
+Testing of the API can be done by creating dummy accounts through the website. To test pledging, it can be useful to:
+
+
+1. Create a Patreon account with creator page and set it to "per post".
+2. Create another Patreon account and use it to pledge to the first account's page. A "per post" pledge will not incur any payments as long as it is cancelled before the end of the month.
+3. Use the API as needed.
+
+
+<aside class="notice">
+    Unfortunately, at this time, we do not offer separate a testing/sandbox API.
+</aside>

--- a/source/includes/_faqs.md
+++ b/source/includes/_faqs.md
@@ -9,5 +9,5 @@ Testing of the API can be done by creating dummy accounts through the website. T
 
 
 <aside class="notice">
-    Unfortunately, at this time, we do not offer separate a testing/sandbox API.
+    Unfortunately, at this time, we do not offer a separate testing/sandbox API.
 </aside>

--- a/source/includes/_oauth.md
+++ b/source/includes/_oauth.md
@@ -82,7 +82,7 @@ POST api.patreon.com/oauth2/token
 	&client_secret=<your client secret>
 	&redirect_uri=<redirect_uri>
 ```
-Your server should handle GET requests in [Step 3](#step-3-handling-oauth-redirect) by performing the following request on the server, not as a redirect
+Your server should handle GET requests in [Step 3](#step-3-handling-oauth-redirect) by performing the following request on the server (not as a redirect):
 
 
 
@@ -167,4 +167,4 @@ POST api.patreon.com/oauth2/token
 ```
 > and you should store this information just as before.
 
-Tokens are valid for up to one month after they are issued. During this period, you may refresh a user’s information using the API calls from step 4. If you wish to get up-to-date information after the token has expired, a new token may be issued to be used for the following month. To refresh a token,
+Tokens are valid for up to one month after they are issued. During this period, you may refresh a user’s information using the API calls from step 4. If you wish to get up-to-date information after the token has expired, a new token may be issued to be used for the following month. To refresh a token, make a POST request to the token endpoint with a grant type of `refresh_token`, as in the example. You may also manually refresh the token on the appropriate client in your [clients page](https://www.patreon.com/platform/start/registerclients).

--- a/source/includes/_oauth.md
+++ b/source/includes/_oauth.md
@@ -75,7 +75,7 @@ When the link in [Step 2](#step-2-making-the-log-in-button) redirects to the pro
 > Request [4]
 
 ```
-POST api.patreon.com/oauth2/token
+POST www.patreon.com/api/oauth2/token
 	?code=<single use code, as passed in to GET route [2]>
 	&grant_type=authorization_code
 	&client_id=<your client id>
@@ -147,7 +147,7 @@ if ($campaign_response['errors']) {
 > Request [7]
 
 ```
-POST api.patreon.com/oauth2/token
+POST www.patreon.com/api/oauth2/token
 	?grant_type=refresh_token
 	&refresh_token=<the user‘s refresh_token>
 	&client_id=<your client id>

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -21,6 +21,7 @@ includes:
 - webhooks
 - external
 - errors
+- faqs
 
 search: true
 ---


### PR DESCRIPTION
- Some sections in `OAuth` were cut off
- All sample urls `api.patreon.com` changed to `www.patreon.com/api`.
- Added FAQs section with instructions on testing w/o sandbox
- Added fields and include instructions in API section.