### PR TITLE
The docs favicon should reflect the rest of our branding

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -31,6 +31,19 @@ under the License.
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <title><%= current_page.data.title || "API Documentation" %></title>
 
+    <link rel="apple-touch-icon" sizes="180x180" href="https://c5.patreon.com/external/favicon/apple-touch-icon.png?v=jw6AR4Rg74">
+    <link rel="icon" type="image/png" sizes="32x32" href="https://c5.patreon.com/external/favicon/favicon-32x32.png?v=69kMELnXkB">
+    <link rel="icon" type="image/png" sizes="16x16" href="https://c5.patreon.com/external/favicon/favicon-16x16.png?v=69kMELnXkB">
+    <link rel="manifest" href="https://c5.patreon.com/external/favicon/manifest.json?v=jw6AR4Rg74">
+    <link rel="mask-icon" href="https://c5.patreon.com/external/favicon/safari-pinned-tab.svg?v=jw6AR4Rg74" color="#f96854">
+    <link rel="shortcut icon" href="https://c5.patreon.com/external/favicon/favicon.ico?v=69kMELnXkB">
+    <meta name="apple-mobile-web-app-title" content="Patreon API Documentation">
+    <meta name="application-name" content="Patreon API Documentation">
+    <meta name="msapplication-TileColor" content="#f96854">
+    <meta name="msapplication-TileImage" content="https://c5.patreon.com/external/favicon/mstile-144x144.png?v=jw6AR4Rg74">
+    <meta name="msapplication-config" content="https://c5.patreon.com/external/favicon/browserconfig.xml?v=jw6AR4Rg74">
+    <meta name="theme-color" content="#f96854">
+
     <style>
       <%= Rouge::Themes::MonokaiSublime.render(:scope => '.highlight') %>
     </style>


### PR DESCRIPTION
Branding should be consistent, and changing the favicon allows for easy visual selection amongst a group of tabs.

Tested this by building locally. None of this is proprietary information, this was taken right from our home page.