### PR TITLE
Document the fact that you can set include=null

### DIFF
--- a/source/includes/_usage.md
+++ b/source/includes/_usage.md
@@ -23,6 +23,9 @@ By default, fetching or including a resource will follow that resource's relatio
 - To include a resource `foo` but not its relationships, set `include=foo.null`.
 - You can also extend this to multiple includes, e.g. `include=foo.null,bar.baz.null`.
 
+For a more explicit approach, you may instead set `json-api-use-default-includes=false`,
+which will limit relationships to only those specifically included.
+
 ## Pagination and sorting
 
 ```shell

--- a/source/includes/_usage.md
+++ b/source/includes/_usage.md
@@ -15,6 +15,14 @@ You can see which attributes or relationships are requestable on a given resourc
 For more information on requesting specific data, the <a href="http://jsonapi.org/format/#fetching-includes">JSONAPI documentation</a> may be useful.
 </aside>
 
+### Restricting included resources
+
+By default, fetching or including a resource will follow that resource's relationship tree as well.
+
+- To fetch a resource without any relationships, set `include=null`.
+- To include a resource `foo` but not its relationships, set `include=foo.null`.
+- You can also extend this to multiple includes, e.g. `include=foo.null,bar.baz.null`.
+
 ## Pagination and sorting
 
 ```shell


### PR DESCRIPTION
This was previously an undocumented feature. It's useful to restrict fetching to only the data you want.