### PR TITLE
Remove .NET 3rd party library

### DIFF
--- a/source/includes/_api-libraries.md
+++ b/source/includes/_api-libraries.md
@@ -69,6 +69,3 @@ There are a number of third party libraries that the developer community has cre
 
 ##Go
 View the source on [github](https://github.com/mxpv/patreon-go)
-
-##.NET
-View the source on [github](https://github.com/shiftos-game/Patreon.NET)


### PR DESCRIPTION
The author of the library took the repo down. The URL is now invalid.