### PR TITLE
Add docs about sparse fieldsets and bracket escaping

### DIFF
--- a/source/includes/_api-endpoints.md
+++ b/source/includes/_api-endpoints.md
@@ -1,4 +1,4 @@
-#API
+#API Endpoints
 
 > To use a given `access_token`, send it in the Authorization HTTPS Header as follows:
 

--- a/source/includes/_usage.md
+++ b/source/includes/_usage.md
@@ -1,4 +1,4 @@
-# Calling the API
+# More Data, Paging, and Sorting
 
 ## Requesting specific data
 

--- a/source/includes/_usage.md
+++ b/source/includes/_usage.md
@@ -15,6 +15,17 @@ You can see which attributes or relationships are requestable on a given resourc
 For more information on requesting specific data, the <a href="http://jsonapi.org/format/#fetching-includes">JSONAPI documentation</a> may be useful.
 </aside>
 
+### Requesting optional attributes
+
+To fetch an optional property (for example `total_historical_amount_cents` and `is_paused` on `pledge`), use the `fields` query params.
+
+`GET https://www.patreon.com/api/oauth2/api/campaigns/<campaign_id>/pledges?fields[pledge]=total_historical_amount_cents,is_paused`
+
+<aside class="warning">
+A common gotcha is forgetting to URL-encode the square brackets.
+For instance, a raw cURL will only work if you replace <code>[</code> with <code>%5B</code> and <code>]</code> with <code>%5D</code>.
+</aside>
+
 ### Restricting included resources
 
 By default, fetching or including a resource will follow that resource's relationship tree as well.
@@ -41,6 +52,11 @@ sort | Comma-separated attributes to sort by, in order of precedence. Each attri
 page[cursor] | From the sorted results, start returning where the first attribute in `sort` equals this value.
 
 The example URL on the right is for 5 pledges with max `created` before 2012-01-19, in reverse chronological order.
+
+<aside class="warning">
+A common gotcha is forgetting to URL-encode the square brackets.
+For instance, a raw cURL will only work if you replace <code>[</code> with <code>%5B</code> and <code>]</code> with <code>%5D</code>.
+</aside>
 
 <aside class="notice">
 For more information on sorting and pagination, the <a href="http://jsonapi.org/format/#fetching-sorting">JSONAPI documentation</a> may be useful.

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -18,7 +18,7 @@ includes:
 - clients
 - oauth
 - resources
-- api
+- api-endpoints
 - usage
 - webhooks
 - external


### PR DESCRIPTION
These are two areas that our docs aren't very clear. Adding these will help prevent developer confusion.