### PR TITLE
PLAT-1055: Re-order docs to put APIv2 first

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -18,14 +18,14 @@ includes:
 - clients
 - oauth
 - errors
-- resources
-- api-endpoints
-- usage
-- webhooks
 - oauth_v2
 - endpoints_v2
 - webhooks_v2
 - resources_v2
+- resources
+- api-endpoints
+- usage
+- webhooks
 - external
 - faqs
 


### PR DESCRIPTION
Since we're committed to people using APIv2, let's list that first on our docs site.

