### PR TITLE
Added info about campaign_lifetime_support_cents to member resource

### DIFF
--- a/source/includes/_resources_v2.md
+++ b/source/includes/_resources_v2.md
@@ -185,6 +185,7 @@ full_name | string | Full name of the member user.
 email | string | The member's email address. Requires the `campaigns.members[email]` scope.
 pledge_relationship_start | string (UTC ISO format) | Datetime of beginning of most recent pledge chainfrom this member to the campaign. Pledge updates do not change this value. Can be null.
 lifetime_support_cents | integer | The total amount that the member has ever paid to the campaign. `0` if never paid.
+campaign_lifetime_support_cents | integer | The total amount that the member has ever paid to the campaign in campaign's currency. `0` if never paid.
 currently_entitled_amount_cents | integer | The amount in cents that the member is entitled to.This includes a current pledge, or payment that covers the current payment period.
 last_charge_date | string (UTC ISO format) | Datetime of last attempted charge. `null` if never charged. Can be null.
 last_charge_status | string | The result of the last attempted charge.The only successful status is `Paid`.`null` if never charged. One of `Paid`, `Declined`, `Deleted`, `Pending`, `Refunded`, `Fraud`, `Other`. Can be null.


### PR DESCRIPTION
**Issue**

campaign_lifetime_support_cents needed to be added to the member resource for api v2.

**Solution**

campaign_lifetime_support_cents info added to v2 member resource.

**Verification**

campaign_lifetime_support_cents info can be seen in the member resource content.

**Does this need tests**

No.