### PR TITLE
/api/oauth2/v2/identity endpoint documentation fix

### DIFF
--- a/source/includes/_endpoints_v2.md
+++ b/source/includes/_endpoints_v2.md
@@ -62,7 +62,7 @@ Fields for each include must be explicitly requested i.e. `fields[campaign]=summ
 You can request related data through includes, ie, `/api/oauth2/v2/identity?include=memberships` and `/api/oauth2/v2/identity?include=campaign`.
 
 - If you request [Campaign](/#campaign-v2) and have the campaigns scope, you will receive information about the user’s [Campaign](/#campaign-v2).
-- If you request [Campaign](/#campaign-v2) and memberships, you will receive information about the user’s [memberships](/#member) and the [Campaign](/#campaign-v2)s they are [Member](/#member) of, provided you have the `campaigns` and `identity[memberships]` scopes.
+- If you request [Campaign](/#campaign-v2) and memberships, you will receive information about the user’s [memberships](/#member) and the [Campaign](/#campaign-v2)s they are [Member](/#member) of, provided you have the `campaigns` and `identity.memberships` scopes.
 - If you request memberships and DON’T have the `identity.memberships` scope, you will receive data about the user’s membership to your campaign. If you DO have the scope, you will receive data about all of the user’s memberships, to all the campaigns they’re members of.
 
 ## GET /api/oauth2/v2/campaigns


### PR DESCRIPTION
Fixed incorrectly written scope in one of the scenarios for /api/oauth2/v2/identity endpoint