### PR TITLE
Remov the bits about apiv2 being in beta and add bits about apiv1 deprecation to intro

### DIFF
--- a/source/includes/_endpoints_v2.md
+++ b/source/includes/_endpoints_v2.md
@@ -1,9 +1,5 @@
 # APIv2: Resource Endpoints
 
-<aside class="aside">
-APIv2 is still in beta, and while the scopes and endpoints are stable, the specific properties returned on the resources may change.
-</aside>
-
 <aside class="notice">
 All API requests should use the hostname https://www.patreon.com
 </aside>

--- a/source/includes/_intro.md
+++ b/source/includes/_intro.md
@@ -23,6 +23,9 @@ We'd love to hear from you.
     </ul>
 </aside>
 
+<aside class="aside">
+APIv2 is maintained whereas APIv1 is slated for deprecation. Please upgrade any integration that is still using v1 to v2. You can come to the <a href="https://discord.com/channels/501792035657744425/751556646232391732">dev-and-api channel</a> at Patreon Discord or <a href="https://www.patreondevelopers.com/c/friendly-help/5">the api help subforum at Patreon Developers forum</a> for your questions and to receive help for upgrading your v1 integration to v2.
+</aside>
 ## Make these docs better
 
 If you find any errors in our docs, we'd love to have you tell us! Submit an issue or a pull request [github repo](https://github.com/Patreon/platform-documentation) and we'll get them fixed up.

--- a/source/includes/_oauth_v2.md
+++ b/source/includes/_oauth_v2.md
@@ -1,9 +1,5 @@
 # APIv2: OAuth
 
-<aside class="aside">
-APIv2 is still in beta, and while the scopes and endpoints are stable, the specific properties returned on the resources may change.
-</aside>
-
 ### What's new?
 At a high level, the main differences between APIv1 and APIv2 are:
 

--- a/source/includes/_webhooks.md
+++ b/source/includes/_webhooks.md
@@ -113,4 +113,4 @@ You can also use our [webhooks page] (https://www.patreon.com/portal/registratio
 
 ### Programmatically Adding Webhooks
 
-In addition to manually adding webhooks, you can also create, read, update, delete and list webhooks with our API. This feature is currently in early beta. If you would like to know more please contact us in <a href="https://www.patreondevelopers.com/" target="_blank">the developers forum</a>.
+In addition to manually adding webhooks, you can also create, read, update, delete and list webhooks with our API. If you would like to know more please contact us in <a href="https://www.patreondevelopers.com/" target="_blank">the developers forum</a>.

--- a/source/includes/_webhooks_v2.md
+++ b/source/includes/_webhooks_v2.md
@@ -1,9 +1,5 @@
 # APIv2: Webhook Endpoints
 
-<aside class="aside">
-APIv2 is still in beta, and while the scopes and endpoints are stable, the specific properties returned on the resources may change.
-</aside>
-
 ## GET /api/oauth2/v2/webhooks
 
 Get the [Webhooks](/#webhook) for the current user's [Campaign](/#campaign-v2) created by the API client. You will only be able to see webhooks created by your client. Requires the `w:campaigns.webhook` scope.


### PR DESCRIPTION
When we tell creators to update their code to v2, they are objecting by saying that the docs say v2 is in beta. This pr removes the bits about v2 being in beta and adds a section to intro about how v2 is being maintained and v1 will be deprecated and calls the creators to update their code to v2. It also includes links to dev-and-api Discord and dev forum's help section for them to come ask for help if needed.