### PR TITLE
Update docs to reflect 100 r/2s as client_id rate limit

### DIFF
--- a/source/includes/_rate_limits.md
+++ b/source/includes/_rate_limits.md
@@ -1,6 +1,6 @@
 # Rate Limits
 
-Patreon implements rate limiting to enhance the security and reliability of its services. Requests are limited by client (1,500 requests per 30 seconds) and by token (100 requests per minute). Please note that refreshing a token will not reset the rate limits.
+Patreon implements rate limiting to enhance the security and reliability of its services. Requests are limited by client (100 requests per 2 seconds) and by token (100 requests per minute). Please note that refreshing a token will not reset the rate limits.
 
 Rate limits are subject to change, and applications should handle HTTP 429 responses gracefully.
 


### PR DESCRIPTION
Update rate limiting documentation specifying that clients are rate limited
at 100 requests per 2 seconds.